### PR TITLE
Allow setting the path where the driver will be downloaded and extracted

### DIFF
--- a/installer/setup.go
+++ b/installer/setup.go
@@ -129,6 +129,11 @@ fmt.Println(string(out[:]))
 func main() {
     var cliFileName string
     var url string
+	
+    if len(os.Args) > 1 {
+        os.Chdir(os.Args[1])
+    }
+
     i:=0
     _,a :=os.LookupEnv("IBM_DB_DIR")
     _,b :=os.LookupEnv("IBM_DB_HOME")


### PR DESCRIPTION
By just changing the current working directory, it would be possible to download and extract the driver in  a custom folder.