### PR TITLE
Installer files are readonly - make sure the user has permission to write 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ syntax:glob
 *.orig
 
 syntax:regexp
+
+installer/*.gz
+installer/clidriver

--- a/installer/setup.go
+++ b/installer/setup.go
@@ -112,7 +112,9 @@ func Untaring(sourcefile string) {
 					fmt.Println(err)
 					os.Exit(1)
 				}
-                err = os.Chmod(filename, os.FileMode(header.Mode))
+				fileMode := os.FileMode(header.Mode)
+				fileMode = fileMode | 0600
+				err = os.Chmod(filename, os.FileMode(fileMode))
                 if err != nil {
                     fmt.Println(err)
                     os.Exit(1)

--- a/installer/setup.go
+++ b/installer/setup.go
@@ -107,7 +107,7 @@ func Untaring(sourcefile string) {
                     fmt.Println(err)
                     os.Exit(1)
                 }
-				_, err = io.Copy(writer, tarBallReader)
+                _, err = io.Copy(writer, tarBallReader)
                 if err != nil {
                     fmt.Println(err)
                     os.Exit(1)

--- a/installer/setup.go
+++ b/installer/setup.go
@@ -108,13 +108,13 @@ func Untaring(sourcefile string) {
                     os.Exit(1)
                 }
 				_, err = io.Copy(writer, tarBallReader)
-				if err != nil {
-					fmt.Println(err)
-					os.Exit(1)
-				}
-				fileMode := os.FileMode(header.Mode)
-				fileMode = fileMode | 0600
-				err = os.Chmod(filename, os.FileMode(fileMode))
+                if err != nil {
+                    fmt.Println(err)
+                    os.Exit(1)
+                }
+                fileMode := os.FileMode(header.Mode)
+                fileMode = fileMode | 0600
+                err = os.Chmod(filename, os.FileMode(fileMode))
                 if err != nil {
                     fmt.Println(err)
                     os.Exit(1)

--- a/installer/setup.go
+++ b/installer/setup.go
@@ -107,7 +107,11 @@ func Untaring(sourcefile string) {
                     fmt.Println(err)
                     os.Exit(1)
                 }
-                io.Copy(writer, tarBallReader)
+				_, err = io.Copy(writer, tarBallReader)
+				if err != nil {
+					fmt.Println(err)
+					os.Exit(1)
+				}
                 err = os.Chmod(filename, os.FileMode(header.Mode))
                 if err != nil {
                     fmt.Println(err)


### PR DESCRIPTION
When I tried to run the client installer setup.go I got some errors:
```
john$ go run setup.go 
darwin
macos64_odbc_cli.tar.gz
Downloading...
download successful
Creating directory : clidriver/
Creating directory : clidriver/bin/
Creating directory : clidriver/bnd/
Creating directory : clidriver/cfg/
Creating directory : clidriver/cfgcache/
Creating directory : clidriver/conv/
Creating directory : clidriver/db2dump/
Untarring : clidriver/db2profile
Creating directory : clidriver/include/
Creating directory : clidriver/lib/
Creating directory : clidriver/license/
Creating directory : clidriver/msg/
Creating directory : clidriver/msg/en_US.iso88591/
Untarring : clidriver/msg/en_US.iso88591/db2adm.mo
open clidriver/msg/en_US.iso88591/db2adm.mo: permission denied
exit status 1
```

After messing around I realized that all files created was readonly, even by the user. I've added a couple of lines to make sure that the user has write permissions to the created files.