### PR TITLE
Simplify setup.go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 syntax:glob
 *.exe
 *.orig
-*.gz
-*.zip
 
 syntax:regexp

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 syntax:glob
 *.exe
 *.orig
+*.gz
+*.zip
 
 syntax:regexp

--- a/installer/setup.go
+++ b/installer/setup.go
@@ -64,9 +64,17 @@ func unzipping(sourcefile string) {
 	}
 }
 
-func linux_untar(clidriver string) {
-	out, _ := exec.Command("tar", "xvzf", clidriver).Output()
-	fmt.Println(string(out[:]))
+func linux_untar(clidriver string, targetDirectory string) error {
+	fmt.Printf("Extracting with tar -xvzf %s -C %s\n", clidriver, targetDirectory)
+	out, err := exec.Command("tar", "xvzf", clidriver, "-C", targetDirectory).Output()
+
+	fmt.Println(string(out))
+	if err != nil {
+		fmt.Println("Error while running tar: " + err.Error())
+		return err
+	}
+
+	return nil
 }
 
 func main() {

--- a/installer/setup.go
+++ b/installer/setup.go
@@ -208,7 +208,7 @@ func main() {
 	}
 
 	if unpackageType == 1 {
-		unzipping(cliFileName)
+		unzipping(cliFileName, path)
 	} else {
 		linux_untar(cliFileName, path)
 	}

--- a/installer/setup.go
+++ b/installer/setup.go
@@ -30,7 +30,7 @@ func downloadFile(filepath string, url string) error {
 	return nil
 }
 
-func unzipping(sourcefile string) {
+func unzipping(sourcefile string, targetDirectory string) {
 	reader, err := zip.OpenReader(sourcefile)
 	if err != nil {
 		fmt.Println(err)
@@ -44,9 +44,13 @@ func unzipping(sourcefile string) {
 			os.Exit(1)
 		}
 		defer zipped.Close()
-		path := filepath.Join("./", f.Name)
+		path := filepath.Join(targetDirectory, f.Name)
 		if f.FileInfo().IsDir() {
-			os.MkdirAll(path, f.Mode())
+			err = os.MkdirAll(path, f.Mode())
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
 			fmt.Println("Creating directory", path)
 		} else {
 			writer, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, f.Mode())


### PR DESCRIPTION
I took some time to simplify and fix your setup.go.

- It looked for one directory and unzipped/untarred in another
- It didn't create the directory it tried to unzip/untar to, which then fails.

I also tried to name variables, for example the variable "i" is sort of non-descriptive, so I changed it to unpackageType. The goes for "a", "b" and "c" as well.

I tried to unfold a number of brackets to make it more readable. So instead of 
```go
if <wantedExpression1> {
    if <wantedExpression2> {
        if <wantedExpression3> {
            doSomething()
        } else {
            fmt.Println("Error message")
        }
    } else {
        fmt.Println("Error message")
    }
} else {
    fmt.Println("Error message")
}
```

I changed it to
```go
if !<wantedExpression1> {
    fmt.Println("Error message")
    return/os.Exit(1)
}
if !<wantedExpression2> {
    fmt.Println("Error message")
    return/os.Exit(1)
}
if !<wantedExpression3> {
    fmt.Println("Error message")
    return/os.Exit(1)
}

doSomething()
```
