### PR TITLE
Avoid register the driver when panic

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -8,6 +8,7 @@ package go_ibm_db
 
 import (
 	"database/sql"
+	"fmt"
 
 	"github.com/ibmdb/go_ibm_db/api"
 )

--- a/driver.go
+++ b/driver.go
@@ -50,6 +50,14 @@ func (d *Driver) Close() error {
 }
 
 func init() {
+	
+	// Recover from panic to avoid stop an application when can't get the db2 cli
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Println(fmt.Sprintf("%s\nThe go_ibm_db driver cannot be registered", err))
+		}
+	}()
+	
 	err := initDriver()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
If panic when driver init then recover and avoid register the driver.

Fixes #57