### PR TITLE
Fix error with column buffer length causing unhandled errors

### DIFF
--- a/column.go
+++ b/column.go
@@ -275,7 +275,10 @@ func (c *BindableColumn) Value(h api.SQLHSTMT, idx int) (driver.Value, error) {
 		return nil, nil
 	}
 	if !c.IsVariableWidth && int(c.Len) != c.Size {
-		panic(fmt.Errorf("wrong column #%d length %d returned, %d expected", idx, c.Len, c.Size))
+		return nil, NewError(fmt.Errorf("wrong column #%d length %d returned, %d expected", idx, c.Len, c.Size))
+	}
+	if len(c.Buffer) < c.Len {
+		return nil, NewError(fmt.Errorf("wrong column buffer #%d length %d returned, %d expected", idx, c.Len, len(c.Buffer)))
 	}
 	return c.BaseColumn.Value(c.Buffer[:c.Len])
 }

--- a/column.go
+++ b/column.go
@@ -275,10 +275,10 @@ func (c *BindableColumn) Value(h api.SQLHSTMT, idx int) (driver.Value, error) {
 		return nil, nil
 	}
 	if !c.IsVariableWidth && int(c.Len) != c.Size {
-		return nil, NewError(fmt.Errorf("wrong column #%d length %d returned, %d expected", idx, c.Len, c.Size))
+		return nil, NewError(fmt.Sprintf("wrong column #%d length %d returned, %d expected", idx, int(c.Len), c.Size), h)
 	}
-	if len(c.Buffer) < c.Len {
-		return nil, NewError(fmt.Errorf("wrong column buffer #%d length %d returned, %d expected", idx, c.Len, len(c.Buffer)))
+	if len(c.Buffer) < int(c.Len) {
+		return nil, NewError(fmt.Sprintf("wrong column buffer #%d length %d returned, %d expected", idx, int(c.Len), len(c.Buffer)), h)
 	}
 	return c.BaseColumn.Value(c.Buffer[:c.Len])
 }


### PR DESCRIPTION
If for any reason the length of the column buffer `c.Buffer` is smaller than `c.Len` you get a ```panic: runtime error: slice bounds out of range``` error.

Also remove the unnecessary panic

Fix #63 