### PR TITLE
Fix handling of os.LookupEnv return code in installer

### DIFF
--- a/installer/setup.go
+++ b/installer/setup.go
@@ -105,8 +105,8 @@ func main() {
 	var target, cliFileName string
 	var unpackageType int
 	fmt.Println("NOTE: Environment variable DB2HOME name is changed to IBM_DB2_HOME.")
-	value, errDir := os.LookupEnv("IBM_DB_HOME")
-	if errDir {
+	value, ok := os.LookupEnv("IBM_DB_HOME")
+	if !ok {
 		if runtime.GOOS == "windows" {
 			fmt.Println("clidriver is already present in this path ", value)
 			fmt.Println("Please add this path to PATH environment variable")


### PR DESCRIPTION
# Fix mishandled return code from os.LookupEnv call

In `installer/setup.go`, the `IBM_DB_HOME` environment variable is retrieved via os.LookupEnv. This function returns a boolean indicating whether or not the variable was found. The implementation currently treats this as an error boolean and fails when it is `true`, blocking the IBM_DB_HOME variable from being used.

This PR addresses the issue by renaming the boolean return variable to `ok`, and running the existing error logic on `!ok`.