### PR TITLE
Removed check for IBM_DB_HOME env variable

### DIFF
--- a/installer/setup.go
+++ b/installer/setup.go
@@ -106,18 +106,6 @@ func main() {
 	var unpackageType int
 
 	fmt.Println("NOTE: Environment variable DB2HOME name is changed to IBM_DB_HOME.")
-	value, ok := os.LookupEnv("IBM_DB_HOME")
-	if !ok {
-		if runtime.GOOS == "windows" {
-			fmt.Println("Please set IBM_DB_HOME and add this path to PATH environment variable")
-			os.Exit(1)
-		} else {
-			fmt.Println("Please set IBM_DB_HOME, CGO_CFLAGS, CGO_LDFLAGS and LD_LIBRARY_PATH or DYLD_LIBRARY_PATH environment variables", value)
-			os.Exit(1)
-		}
-	}
-
-
 
 	if len(os.Args) == 2 {
 		target = os.Args[1]


### PR DESCRIPTION
Since user doesn’t have **clidriver** available in his/her System. So, he/she will not have path for **IBM_DB_HOME** because he/she needs to first download it. Then he/she can set it.