### PR TITLE
Fixing Release Handle

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -75,7 +75,7 @@ func (c *Conn) Query(query string, args []driver.Value) (driver.Rows, error) {
 	os = &ODBCStmt{
 		h:          h,
 		Parameters: ps,
-		usedByStmt: true}
+		usedByRows: true}
 	err = os.BindColumns()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Changed usedByStmt to usedByRows, to solve direct queries release handle problem. See comments on issue #145  and  #203 