### PR TITLE
Fix issue #210 The gbk encoded Chinese field may be truncated when read in the utf8 operating environment

### DIFF
--- a/column.go
+++ b/column.go
@@ -248,7 +248,8 @@ func NewVariableWidthColumn(b *BaseColumn, ctype api.SQLSMALLINT, colWidth api.S
 		if b.SType == api.SQL_DECIMAL {
 			l = l + 4 // adding 4 as decimal has '.' which takes 1 byte
 		} else {
-			l++ // room for null-termination character
+			l++    // room for null-termination character
+			l *= 2 // chars take 2 bytes each
 		}
 	case api.SQL_C_BINARY:
 		// nothing to do


### PR DESCRIPTION
fix issue #210  The driver reads the gbk encoded varchar field. The Chinese is returned as 3 bytes. The default buffer length is defined as the field length, which is shorter than the actual read length