### PR TITLE
The gbk encoded Chinese field may be truncated when read in the utf8 operating environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Interface for GoLang to DB2 for z/OS, DB2 for LUW, DB2 for i.
 
 ## Prerequisite
 
-Golang should be installed(Golang version should be >=1.12.x and <= 1.19.X)
+Golang should be installed(Golang version should be >=1.12.x and <= 1.20.X)
 
 Git should be installed in your system.
 
@@ -27,7 +27,7 @@ Environment variable DB2HOME name is changed to IBM_DB_HOME.
 You may install go_ibm_db using either of below commands
 go get -d github.com/ibmdb/go_ibm_db
 go install github.com/ibmdb/go_ibm_db/installer@latest
-go install github.com/ibmdb/go_ibm_db/installer@v0.4.2
+go install github.com/ibmdb/go_ibm_db/installer@v0.4.3
 
 If you already have a clidriver available in your system, add the path of the same to your Path windows environment variable
 Example: Path = C:\Program Files\IBM\IBM DATA SERVER DRIVER\bin

--- a/column.go
+++ b/column.go
@@ -248,7 +248,8 @@ func NewVariableWidthColumn(b *BaseColumn, ctype api.SQLSMALLINT, colWidth api.S
 		if b.SType == api.SQL_DECIMAL {
 			l = l + 4 // adding 4 as decimal has '.' which takes 1 byte
 		} else {
-			l++ // room for null-termination character
+			l++     // room for null-termination character
+			l *= 2  //chars take 2 bytes each
 		}
 	case api.SQL_C_BINARY:
 		// nothing to do


### PR DESCRIPTION
The driver reads the gbk encoded varchar field. The Chinese is returned as 3 bytes. The default buffer length is defined as the field length, which is shorter than the actual read length . Updated the README.md.