### PR TITLE
Fix: pass integer values into SQLSetEnvAttr and SQLSetConnectAttr

### DIFF
--- a/api/api_unix.go
+++ b/api/api_unix.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build (aix || darwin || linux) && cgo
 // +build aix darwin linux
 // +build cgo
 
@@ -11,6 +12,16 @@ package api
 // #cgo darwin LDFLAGS: -ldb2
 // #cgo linux LDFLAGS: -ldb2
 // #include <sqlcli1.h>
+// #include <stdint.h>
+/*
+SQLRETURN sqlSetEnvUIntPtrAttr(SQLHENV environmentHandle, SQLINTEGER attribute, uintptr_t valuePtr, SQLINTEGER stringLength) {
+	return SQLSetEnvAttr(environmentHandle, attribute, (SQLPOINTER)valuePtr, stringLength);
+}
+
+SQLRETURN sqlSetConnectUIntPtrAttr(SQLHDBC connectionHandle, SQLINTEGER attribute, uintptr_t valuePtr, SQLINTEGER stringLength) {
+	return SQLSetConnectAttr(connectionHandle, attribute, (SQLPOINTER)valuePtr, stringLength);
+}
+*/
 import "C"
 
 const (
@@ -159,3 +170,13 @@ type (
 	SQLLEN  C.SQLLEN
 	SQLULEN C.SQLULEN
 )
+
+func SQLSetEnvUIntPtrAttr(environmentHandle SQLHENV, attribute SQLINTEGER, valuePtr uintptr, stringLength SQLINTEGER) (ret SQLRETURN) {
+	r := C.sqlSetEnvUIntPtrAttr(C.SQLHENV(environmentHandle), C.SQLINTEGER(attribute), C.uintptr_t(valuePtr), C.SQLINTEGER(stringLength))
+	return SQLRETURN(r)
+}
+
+func SQLSetConnectUIntPtrAttr(connectionHandle SQLHDBC, attribute SQLINTEGER, valuePtr uintptr, stringLength SQLINTEGER) (ret SQLRETURN) {
+	r := C.sqlSetConnectUIntPtrAttr(C.SQLHDBC(connectionHandle), C.SQLINTEGER(attribute), C.uintptr_t(valuePtr), C.SQLINTEGER(stringLength))
+	return SQLRETURN(r)
+}

--- a/api/api_windows.go
+++ b/api/api_windows.go
@@ -4,6 +4,10 @@
 
 package api
 
+import (
+	"syscall"
+)
+
 const (
 	SQL_OV_ODBC3 = 3
 
@@ -155,3 +159,15 @@ type (
 		Data4 [8]byte
 	}
 )
+
+func SQLSetEnvUIntPtrAttr(environmentHandle SQLHENV, attribute SQLINTEGER, valuePtr uintptr, stringLength SQLINTEGER) (ret SQLRETURN) {
+	r0, _, _ := syscall.Syscall6(procSQLSetEnvAttr.Addr(), 4, uintptr(environmentHandle), uintptr(attribute), uintptr(valuePtr), uintptr(stringLength), 0, 0)
+	ret = SQLRETURN(r0)
+	return
+}
+
+func SQLSetConnectUIntPtrAttr(connectionHandle SQLHDBC, attribute SQLINTEGER, valuePtr uintptr, stringLength SQLINTEGER) (ret SQLRETURN) {
+	r0, _, _ := syscall.Syscall6(procSQLSetConnectAttrW.Addr(), 4, uintptr(connectionHandle), uintptr(attribute), uintptr(valuePtr), uintptr(stringLength), 0, 0)
+	ret = SQLRETURN(r0)
+	return
+}

--- a/driver.go
+++ b/driver.go
@@ -33,8 +33,8 @@ func initDriver() error {
 	drv.Stats.updateHandleCount(api.SQL_HANDLE_ENV, 1)
 
 	// will use ODBC v3
-	ret = api.SQLSetEnvAttr(drv.h, api.SQL_ATTR_ODBC_VERSION,
-		api.SQLPOINTER(api.SQL_OV_ODBC3), 0)
+	ret = api.SQLSetEnvUIntPtrAttr(drv.h, api.SQL_ATTR_ODBC_VERSION,
+		api.SQL_OV_ODBC3, 0)
 	if IsError(ret) {
 		defer releaseHandle(drv.h)
 		return NewError("SQLSetEnvAttr ODBC v3", drv.h)
@@ -51,14 +51,14 @@ func (d *Driver) Close() error {
 }
 
 func init() {
-	
+
 	// Recover from panic to avoid stop an application when can't get the db2 cli
 	defer func() {
 		if err := recover(); err != nil {
 			fmt.Println(fmt.Sprintf("%s\nThe go_ibm_db driver cannot be registered", err))
 		}
 	}()
-	
+
 	err := initDriver()
 	if err != nil {
 		panic(err)

--- a/tx.go
+++ b/tx.go
@@ -16,10 +16,10 @@ type Tx struct {
 }
 
 func (c *Conn) setAutoCommitAttr(a uintptr) error {
-	ret := api.SQLSetConnectAttr(c.h, api.SQL_ATTR_AUTOCOMMIT,
-		api.SQLPOINTER(a), api.SQL_IS_UINTEGER)
+	ret := api.SQLSetConnectUIntPtrAttr(c.h, api.SQL_ATTR_AUTOCOMMIT,
+		a, api.SQL_IS_UINTEGER)
 	if IsError(ret) {
-		return NewError("SQLSetConnectAttr", c.h)
+		return NewError("SQLSetConnectUIntPtrAttr", c.h)
 	}
 	return nil
 }


### PR DESCRIPTION
pass integer values into SQLSetEnvAttr and SQLSetConnectAttr via uintptr

this should stop gc compaining about them look like invalid pointers

Fixes issue #208