### PR TITLE
Add env var for cli driver download url

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,16 @@ go get -d github.com/ibmdb/go_ibm_db
 go install github.com/ibmdb/go_ibm_db/installer@latest
 go install github.com/ibmdb/go_ibm_db/installer@v0.4.3
 
+You can optionally specify a specific cli driver by setting the IBM_DB_DOWNLOAD_URL environment variable to the full path of your desired cli driver.  For example, if you want to install the 64-bit macos v11.5.4 cli driver instead of the latest one, set the variable as below:
+
+export IBM_DB_DOWNLOAD_URL=https://public.dhe.ibm.com/ibmdl/export/pub/software/data/db2/drivers/odbc_cli/v11.5.4/macos64_odbc_cli.tar.gz
+
 If you already have a clidriver available in your system, add the path of the same to your Path windows environment variable
 Example: Path = C:\Program Files\IBM\IBM DATA SERVER DRIVER\bin
-
 
 If you do not have a clidriver in your system, go to installer folder where go_ibm_db is downloaded in your system, use below command: 
 (Example: C:\Users\uname\go\src\github.com\ibmdb\go_ibm_db\installer or C:\Users\uname\go\pkg\mod\github.com\ibmdb\go_ibm_db\installer 
  where uname is the username ) and run setup.go file (go run setup.go).
-
 
 Set IBM_DB_HOME to clidriver downloaded path and
 set this path to your PATH windows environment variable
@@ -61,6 +63,9 @@ go get -d github.com/ibmdb/go_ibm_db
 go install github.com/ibmdb/go_ibm_db/installer@latest
 go install github.com/ibmdb/go_ibm_db/installer@v0.4.2
 
+You can optionally specify a specific cli driver by setting the IBM_DB_DOWNLOAD_URL environment variable to the full path of your desired driver.  For example, if you want to install the 64-bit macos v11.5.4 cli driver instead of the latest one, set the variable as below:
+
+export IBM_DB_DOWNLOAD_URL=https://public.dhe.ibm.com/ibmdl/export/pub/software/data/db2/drivers/odbc_cli/v11.5.4/macos64_odbc_cli.tar.gz
 
 If you already have a clidriver available in your system, set the below environment variables with the clidriver path
 

--- a/installer/setup.go
+++ b/installer/setup.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"archive/zip"
+	"bufio"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,7 +11,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"bufio"
 )
 
 func downloadFile(filepath string, url string) error {
@@ -108,19 +108,19 @@ func getinstalledpath(validateout string) {
 	scanner := bufio.NewScanner(strings.NewReader(validateout))
 
 	for scanner.Scan() {
-		line  = scanner.Text()
+		line = scanner.Text()
 
-		if(strings.Contains(line, "Install")) {
+		if strings.Contains(line, "Install") {
 			fields := strings.Split(line, " ")
 			fmt.Println(fields[7])
-			input1 :=  fields[7][0:len(fields[7])]
-		        fmt.Println("Clidriver is already present")
+			input1 := fields[7][0:len(fields[7])]
+			fmt.Println("Clidriver is already present")
 			fmt.Println("Please set IBM_DB_HOME to ", input1)
 		}
 	}
 }
 
-func checkincludepath( includepath string) bool {
+func checkincludepath(includepath string) bool {
 
 	if _, err1 := os.Stat(includepath + "/include"); !os.IsNotExist(err1) {
 		//fmt.Println("clidriver/include folder exists in the path")
@@ -151,20 +151,19 @@ func main() {
 				fmt.Println("Please set IBM_DB_HOME, CGO_CFLAGS, CGO_LDFLAGS and LD_LIBRARY_PATH or DYLD_LIBRARY_PATH environment variables after clidriver installed")
 			}
 		}
-	}else {
+	} else {
 		path, ok := os.LookupEnv("IBM_DB_HOME")
 		if !ok {
 			//set IBM_DB_HOME
 			getinstalledpath(string(out))
 			os.Exit(1)
-		}else{
+		} else {
 			fmt.Println("clidriver folder exists in the path....", path)
 			if checkincludepath(path) {
 				os.Exit(1)
 			}
 		}
 	}
-
 
 	if len(os.Args) == 2 {
 		target = os.Args[1]
@@ -270,7 +269,7 @@ func main() {
 		fmt.Println("not known platform")
 		os.Exit(3)
 	}
-	fileUrl := "https://public.dhe.ibm.com/ibmdl/export/pub/software/data/db2/drivers/odbc_cli/" + cliFileName
+	fileUrl := downloadUrl(cliFileName)
 	fmt.Println("Downloading " + fileUrl)
 	err := downloadFile(cliFileName, fileUrl)
 	if err != nil {
@@ -286,4 +285,12 @@ func main() {
 	} else {
 		linux_untar(cliFileName, target)
 	}
+}
+
+func downloadUrl(cliFileName string) string {
+	downloadUrl, downloadUrlFound := os.LookupEnv("IBM_DB_DOWNLOAD_URL")
+	if !downloadUrlFound {
+		downloadUrl = "https://public.dhe.ibm.com/ibmdl/export/pub/software/data/db2/drivers/odbc_cli/" + cliFileName
+	}
+	return downloadUrl
 }


### PR DESCRIPTION
This changes allows for better control of which cli driver is installed by supplying a download url in the CLI_DRIVER_DOWNLOAD_URL environment variable.  The default remains the same.

Addresses #228 