### PR TITLE
use the environment variable GO_IBM_DB2_TRACE to set trace filepath, not flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,9 +610,11 @@ connStr = "DATABASE=database;HOSTNAME=hostname;PORT=port;PROTOCOL=TCPIP;UID=dbus
 
 ```
 # Log on console:
-go run sample.go -trace
+export GO_IBMDB_TRACE=stdout
+go run sample.go
 
 # Log to a file (e.g., log.txt)
-go run sample.go -trace log.txt
+export GO_IBMDB_TRACE=log.txt
+go run sample.go
 
 ```

--- a/driver.go
+++ b/driver.go
@@ -9,7 +9,6 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/ibmdb/go_ibm_db/api"
 	trc "github.com/ibmdb/go_ibm_db/log2"
@@ -59,15 +58,7 @@ func (d *Driver) Close() error {
 }
 
 func init() {
-	trc.GetPath(os.Getenv("GO_IBM_DB2_TRACE"))
-
-	var cmdStr string = ""
-	for e := 0; e < len(os.Args); e++ {
-		cmdStr = cmdStr + os.Args[e]
-	}
-	if strings.Contains(cmdStr, "trace") {
-		fmt.Println("Warning: The trace flag is deprecated. Please use the GO_IBM_DB2_TRACE environment variable instead.")
-	}
+	trc.GetPath(os.Getenv("GO_IBMDB_TRACE"))
 
 	trc.Trace1("driver.go:init() - ENTRY")
 

--- a/driver.go
+++ b/driver.go
@@ -7,7 +7,6 @@ package go_ibm_db
 
 import (
 	"database/sql"
-	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -60,19 +59,14 @@ func (d *Driver) Close() error {
 }
 
 func init() {
-	var cmdStr string = ""
+	trc.GetPath(os.Getenv("GO_IBM_DB2_TRACE"))
 
+	var cmdStr string = ""
 	for e := 0; e < len(os.Args); e++ {
 		cmdStr = cmdStr + os.Args[e]
 	}
-
 	if strings.Contains(cmdStr, "trace") {
-		wordPtr := flag.String("trace", "", "log/trace file name")
-
-		if len(os.Args) > 2 {
-			flag.Parse()
-		}
-		trc.GetPath(*wordPtr, len(os.Args))
+		fmt.Println("Warning: The trace flag is deprecated. Please use the GO_IBM_DB2_TRACE environment variable instead.")
 	}
 
 	trc.Trace1("driver.go:init() - ENTRY")

--- a/log2/logger1.go
+++ b/log2/logger1.go
@@ -6,44 +6,48 @@
 package log2
 
 import (
+	"fmt"
 	"log"
 	"os"
-	"fmt"
 )
 
 var globalvar string = ""
-var globalArgsLen int = 0
 
-func GetPath(filename string, argsLen int) {
+func GetPath(filename string) {
 	//fmt.Println("filename = ", filename)
 	//fmt.Println("Args Length = ", argsLen)
 
 	if _, err := os.Stat(filename); err == nil {
-        //fmt.Println("File exits\n")
+		//fmt.Println("File exits\n")
 		e := os.Remove(filename)
 		if e != nil {
-		  fmt.Println("Problem in removing existing log file")
+			fmt.Println("Problem in removing existing log file")
 		}
 	}
 
 	globalvar = filename
-	globalArgsLen = argsLen
-
 }
 
 func Trace1(msg1 string) {
-    if globalvar != "" {
-		//file, errlog := os.OpenFile("C:\\temp\\testlogs2.txt", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
-		file, errlog := os.OpenFile(globalvar, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
-		if errlog != nil {
-			log.Fatal(errlog)
-		}
-		log.SetOutput(file)
-		log.Println(msg1)
-    } else if globalArgsLen > 1 {
-	    log.SetOutput(os.Stdout)
-		log.Println(msg1)
+	if globalvar == "" {
+		return
 	}
 
-}
+	if globalvar == "stdout" {
+		log.SetOutput(os.Stdout)
+		log.Println(msg1)
+		return
+	}
 
+	//file, errlog := os.OpenFile("C:\\temp\\testlogs2.txt", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+	file, errlog := os.OpenFile(globalvar, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+	if errlog != nil {
+		log.Fatal(errlog)
+	}
+	defer file.Close()
+
+	log.SetOutput(file)
+	log.Println(msg1)
+
+	file.Sync()
+}

--- a/log2/logger1.go
+++ b/log2/logger1.go
@@ -17,11 +17,13 @@ func GetPath(filename string) {
 	//fmt.Println("filename = ", filename)
 	//fmt.Println("Args Length = ", argsLen)
 
-	if _, err := os.Stat(filename); err == nil {
-		//fmt.Println("File exits\n")
-		e := os.Remove(filename)
-		if e != nil {
-			fmt.Println("Problem in removing existing log file")
+	if filename != "" && filename != "stdout" {
+		if _, err := os.Stat(filename); err == nil {
+			//fmt.Println("File exits\n")
+			e := os.Remove(filename)
+			if e != nil {
+				fmt.Println("Problem in removing existing log file")
+			}
 		}
 	}
 


### PR DESCRIPTION
When `flag.Parse()` encounters unused flags, it calls `os.Exit(2)`, So `a.exe -trace a.log -yyy false` will failed.